### PR TITLE
Skip idea folder while cloning repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 /build
 /captures
+/.idea/


### PR DESCRIPTION
Idea files usually have local information which causes issues when cloned, best to keep it out of git versioning.